### PR TITLE
Validate that PV selection is valid

### DIFF
--- a/src/app/home/pages/PlansPage/components/Wizard/VolumesForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/VolumesForm.tsx
@@ -1,24 +1,15 @@
-import React, { useEffect } from 'react';
+import { StatusIcon } from '@konveyor/lib-ui';
+import { Grid, GridItem } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
-import { IFormValues, IOtherProps } from './WizardContainer';
-import VolumesTable from './VolumesTable';
-import {
-  Grid,
-  GridItem,
-  Bullseye,
-  EmptyState,
-  Spinner,
-  Title,
-  Alert,
-} from '@patternfly/react-core';
-import { StatusIcon, StatusType } from '@konveyor/lib-ui';
-import { IPlanPersistentVolume } from '../../../../../plan/duck/types';
-import { usePausedPollingEffect } from '../../../../../common/context';
-import { OptionLike, OptionWithValue } from '../../../../../common/components/SimpleSelect';
-import { useDispatch, useSelector } from 'react-redux';
-import { PlanActions } from '../../../../../plan/duck/actions';
-import { DefaultRootState } from '../../../../../../configureStore';
 import { isEmpty } from 'lodash';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { DefaultRootState } from '../../../../../../configureStore';
+import { usePausedPollingEffect } from '../../../../../common/context';
+import { PlanActions } from '../../../../../plan/duck/actions';
+import { IPlanPersistentVolume } from '../../../../../plan/duck/types';
+import VolumesTable from './VolumesTable';
+import { IFormValues, IOtherProps } from './WizardContainer';
 
 const styles = require('./VolumesTable.module').default;
 
@@ -110,34 +101,6 @@ const VolumesForm: React.FunctionComponent<IOtherProps> = (props) => {
       </Grid>
     );
   }
-  if (
-    planState.isFetchingPVResources ||
-    planState.isPollingStatus ||
-    planState.currentPlanStatus.state === 'Pending'
-  ) {
-    return (
-      <Bullseye>
-        <EmptyState variant="large">
-          <div className="pf-c-empty-state__icon">
-            <Spinner size="xl" />
-          </div>
-          <Title headingLevel="h2" size="xl">
-            Discovering persistent volumes attached to source projects...
-          </Title>
-        </EmptyState>
-      </Bullseye>
-    );
-  }
-  if (planState.currentPlanStatus.state === 'Critical') {
-    return (
-      <Bullseye>
-        <EmptyState variant="large">
-          <Alert variant="danger" isInline title={planState.currentPlanStatus.errorMessage} />
-        </EmptyState>
-      </Bullseye>
-    );
-  }
-
   return (
     <VolumesTable
       isEdit={props.isEdit}

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
@@ -348,6 +348,7 @@ const WizardComponent = (props: IOtherProps) => {
                   !isFetchingPVList &&
                   currentPlanStatus.state !== 'Pending' &&
                   currentPlanStatus.state !== 'Critical' &&
+                  !planState.currentPlan.spec.refresh &&
                   (values.migrationType.value !== 'scc' ||
                     (values.selectedPVs.length > 0 && storageClasses.length > 1))
                 );


### PR DESCRIPTION
Instead of validating that Migration Plans don't
share the same namespace, validate that the PVs
selected are not shared between Migration Plans.

This validation happens on the backend and these
modification are to allow the UI to display the
proper progress and error messages in the PV
selection table.

Matches https://github.com/migtools/mig-controller/pull/1393 which modifies the validation to selected PVs in namespaces instead of namespaces