### PR TITLE
Add volume mode and access mode selection for VM related volumes in the Persistent Volume grid

### DIFF
--- a/src/app/common/components/SimpleSelect.tsx
+++ b/src/app/common/components/SimpleSelect.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react';
 import {
   Select,
   SelectOption,
   SelectOptionObject,
-  SelectProps,
   SelectOptionProps,
+  SelectProps,
 } from '@patternfly/react-core';
+import React, { useState } from 'react';
 
 import './SimpleSelect.css';
 
@@ -51,6 +51,7 @@ const SimpleSelect: React.FunctionComponent<ISimpleSelectProps> = ({
         <SelectOption
           key={option.toString()}
           value={option}
+          description={(option as OptionWithValue)?.props?.description}
           {...(typeof option === 'object' && (option as OptionWithValue).props)}
         />
       ))}

--- a/src/app/home/pages/PlansPage/components/PlanActions/PlanActionsComponent.tsx
+++ b/src/app/home/pages/PlansPage/components/PlanActions/PlanActionsComponent.tsx
@@ -1,21 +1,20 @@
-import React from 'react';
-import { useState } from 'react';
 import {
   Dropdown,
+  DropdownGroup,
   DropdownItem,
   DropdownPosition,
-  KebabToggle,
   Flex,
   FlexItem,
-  DropdownGroup,
+  KebabToggle,
 } from '@patternfly/react-core';
-import { useOpenModal } from '../../../../duck';
-import { useHistory } from 'react-router-dom';
-import WizardContainer from '../Wizard/WizardContainer';
-import ConfirmModal from '../../../../../common/components/ConfirmModal';
-import { IPlan } from '../../../../../plan/duck/types';
+import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import ConfirmModal from '../../../../../common/components/ConfirmModal';
 import { PlanActions } from '../../../../../plan/duck';
+import { IPlan } from '../../../../../plan/duck/types';
+import { useOpenModal } from '../../../../duck';
+import WizardContainer from '../Wizard/WizardContainer';
 import { MigrationActionsDropdownGroup } from './MigrationActionsDropdownGroup';
 import { MigrationConfirmModals, useMigrationConfirmModalState } from './MigrationConfirmModals';
 interface IPlanActionsProps {

--- a/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
@@ -1,18 +1,18 @@
-import React, { useEffect, useRef } from 'react';
-import { useFormikContext } from 'formik';
-import { IFormValues } from './WizardContainer';
-import { Form, FormGroup, TextContent, Text, TextInput, Tooltip } from '@patternfly/react-core';
-import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import SimpleSelect, { OptionWithValue } from '../../../../../common/components/SimpleSelect';
-import { useForcedValidationOnChange } from '../../../../../common/duck/hooks';
-import { validatedState } from '../../../../../common/helpers';
-import { ICluster } from '../../../../../cluster/duck/types';
+import { Form, FormGroup, Text, TextContent, TextInput, Tooltip } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
-import { usePausedPollingEffect } from '../../../../../common/context';
-import { IStorage } from '../../../../../storage/duck/types';
-import { MigrationType } from '../../types';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { useFormikContext } from 'formik';
+import React, { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { DefaultRootState } from '../../../../../../configureStore';
+import { ICluster } from '../../../../../cluster/duck/types';
+import SimpleSelect, { OptionWithValue } from '../../../../../common/components/SimpleSelect';
+import { usePausedPollingEffect } from '../../../../../common/context';
+import { useForcedValidationOnChange } from '../../../../../common/duck/hooks';
+import { validatedState } from '../../../../../common/helpers';
+import { IStorage } from '../../../../../storage/duck/types';
+import { MigrationType } from '../../types';
+import { IFormValues } from './WizardContainer';
 
 export type IGeneralFormProps = {
   isEdit: boolean;

--- a/src/app/home/pages/PlansPage/components/Wizard/PVAccessModeSelect.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/PVAccessModeSelect.tsx
@@ -1,0 +1,66 @@
+import { useFormikContext } from 'formik';
+import React from 'react';
+import SimpleSelect, { OptionWithValue } from '../../../../../common/components/SimpleSelect';
+import {
+  IMigPlanStorageClass,
+  IPlanPersistentVolume,
+  IVolumeAccessModes,
+} from '../../../../../plan/duck/types';
+import { IFormValues } from './WizardContainer';
+
+const styles = require('./PVStorageClassSelect.module').default;
+
+interface IPVAccessModeSelectProps {
+  pv: IPlanPersistentVolume;
+  currentPV: IPlanPersistentVolume;
+  storageClasses: IMigPlanStorageClass[];
+}
+
+export const PVAccessModeSelect: React.FunctionComponent<IPVAccessModeSelectProps> = ({
+  pv,
+  currentPV,
+  storageClasses,
+}: IPVAccessModeSelectProps) => {
+  const { values, setFieldValue } = useFormikContext<IFormValues>();
+
+  const currentStorageClass = values.pvStorageClassAssignment[currentPV.name];
+  const volumeAccessModes = currentStorageClass.volumeAccessModes;
+  const currentVolumeMode = currentStorageClass.volumeMode;
+  const possibleAccessModes = volumeAccessModes.find(
+    (volumeAccessMode: IVolumeAccessModes) => volumeAccessMode.volumeMode === currentVolumeMode
+  ) || { accessModes: [] as string[] };
+
+  const onAccessModeChange = (currentPV: IPlanPersistentVolume, value: string) => {
+    currentStorageClass.accessMode = value;
+    const updatedAssignment = {
+      ...values.pvStorageClassAssignment,
+      [currentPV.name]: currentStorageClass,
+    };
+    setFieldValue('pvStorageClassAssignment', updatedAssignment);
+  };
+
+  const accessModeOptions: OptionWithValue[] = [
+    ...possibleAccessModes.accessModes.map((value: string) => ({
+      value: value,
+      toString: () => value,
+    })),
+  ];
+  accessModeOptions.splice(1, 1); // remove ReadOnly option
+  accessModeOptions.splice(0, 0, { value: 'auto', toString: () => 'Auto' });
+
+  return (
+    <SimpleSelect
+      id="select-storage-class"
+      aria-label="Select storage class"
+      className={styles.copySelectStyle}
+      onChange={(option: any) => onAccessModeChange(currentPV, option.value)}
+      options={accessModeOptions}
+      placeholderText="Select volume mode..."
+      value={
+        accessModeOptions.find(
+          (option) => currentStorageClass && option.value === currentStorageClass.accessMode
+        ) || accessModeOptions[0]
+      }
+    />
+  );
+};

--- a/src/app/home/pages/PlansPage/components/Wizard/PVStorageClassSelect.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/PVStorageClassSelect.tsx
@@ -20,24 +20,26 @@ export const PVStorageClassSelect: React.FunctionComponent<IPVStorageClassSelect
 }: IPVStorageClassSelectProps) => {
   const { values, setFieldValue } = useFormikContext<IFormValues>();
 
-  const currentStorageClass = values.pvStorageClassAssignment[pv.name];
+  const currentStorageClass = values.pvStorageClassAssignment[currentPV.name];
 
   const onStorageClassChange = (currentPV: IPlanPersistentVolume, value: string) => {
-    const newSc = storageClasses.find((sc) => sc !== '' && sc.name === value) || '';
+    const newSc = storageClasses.find((sc) => sc.name === value) || '';
+    const copy = JSON.parse(JSON.stringify(newSc));
+    copy.volumeMode = 'auto';
+    copy.accessMode = 'auto';
     const updatedAssignment = {
       ...values.pvStorageClassAssignment,
-      [currentPV.name]: newSc,
+      [currentPV.name]: copy,
     };
     setFieldValue('pvStorageClassAssignment', updatedAssignment);
   };
 
-  const noneOption = { value: '', toString: () => 'None' };
   const storageClassOptions: OptionWithValue[] = [
     ...storageClasses.map((storageClass) => ({
-      value: storageClass !== '' && storageClass.name,
+      value: storageClass.name,
       toString: () => targetStorageClassToString(storageClass),
+      props: { description: storageClass.provisioner },
     })),
-    noneOption,
   ];
 
   return (
@@ -48,11 +50,9 @@ export const PVStorageClassSelect: React.FunctionComponent<IPVStorageClassSelect
       onChange={(option: any) => onStorageClassChange(currentPV, option.value)}
       options={storageClassOptions}
       value={
-        currentStorageClass === ''
-          ? noneOption
-          : storageClassOptions.find(
-              (option) => currentStorageClass && option.value === currentStorageClass.name
-            ) || undefined
+        storageClassOptions.find(
+          (option) => currentStorageClass && option.value === currentStorageClass.name
+        ) || undefined
       }
       placeholderText="Select a storage class..."
     />

--- a/src/app/home/pages/PlansPage/components/Wizard/PVVolumeModeSelect.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/PVVolumeModeSelect.tsx
@@ -1,0 +1,61 @@
+import { useFormikContext } from 'formik';
+import React from 'react';
+import SimpleSelect, { OptionWithValue } from '../../../../../common/components/SimpleSelect';
+import {
+  IMigPlanStorageClass,
+  IPlanPersistentVolume,
+  IVolumeAccessModes,
+} from '../../../../../plan/duck/types';
+import { IFormValues } from './WizardContainer';
+
+const styles = require('./PVStorageClassSelect.module').default;
+
+interface IPVVolumeModeSelectProps {
+  pv: IPlanPersistentVolume;
+  currentPV: IPlanPersistentVolume;
+  storageClasses: IMigPlanStorageClass[];
+}
+
+export const PVVolumeModeSelect: React.FunctionComponent<IPVVolumeModeSelectProps> = ({
+  pv,
+  currentPV,
+  storageClasses,
+}: IPVVolumeModeSelectProps) => {
+  const { values, setFieldValue } = useFormikContext<IFormValues>();
+
+  const currentStorageClass = values.pvStorageClassAssignment[currentPV.name];
+  const volumeAccessModes = currentStorageClass.volumeAccessModes;
+
+  const onVolumeModeChange = (currentPV: IPlanPersistentVolume, value: string) => {
+    currentStorageClass.volumeMode = value;
+    const updatedAssignment = {
+      ...values.pvStorageClassAssignment,
+      [currentPV.name]: currentStorageClass,
+    };
+    setFieldValue('pvStorageClassAssignment', updatedAssignment);
+  };
+
+  const volumeModeOptions: OptionWithValue[] = [
+    ...volumeAccessModes.map((volumeAccessMode: IVolumeAccessModes) => ({
+      value: volumeAccessMode.volumeMode,
+      toString: () => volumeAccessMode.volumeMode,
+    })),
+  ];
+  volumeModeOptions.splice(0, 0, { value: 'auto', toString: () => 'Auto' });
+
+  return (
+    <SimpleSelect
+      id="select-storage-class"
+      aria-label="Select storage class"
+      className={styles.copySelectStyle}
+      onChange={(option: any) => onVolumeModeChange(currentPV, option.value)}
+      options={volumeModeOptions}
+      placeholderText="Select volume mode..."
+      value={
+        volumeModeOptions.find(
+          (option) => currentStorageClass && option.value === currentStorageClass.volumeMode
+        ) || volumeModeOptions[0]
+      }
+    />
+  );
+};

--- a/src/app/home/pages/PlansPage/helpers.ts
+++ b/src/app/home/pages/PlansPage/helpers.ts
@@ -401,7 +401,13 @@ export const getElapsedTime = (step: IStep, migration: IMigration): string => {
 export type IPlanInfo = ReturnType<typeof getPlanInfo>;
 
 export const targetStorageClassToString = (storageClass: IMigPlanStorageClass) =>
-  storageClass && `${storageClass.name}:${storageClass.provisioner}`;
+  storageClass && `${storageClass.name}`;
+
+export const targetVolumeModeToString = (storageClass: IMigPlanStorageClass) =>
+  storageClass && `${storageClass.volumeMode}`;
+
+export const targetAccessModeToString = (storageClass: IMigPlanStorageClass) =>
+  storageClass && `${storageClass.accessMode}`;
 
 export const pvcNameToString = (pvc: IPlanPersistentVolume['pvc']) => {
   const includesMapping = pvc.name.includes(':');
@@ -491,11 +497,14 @@ export const getSuggestedPvStorageClasses = (migPlan?: IMigPlan) => {
   const storageClasses = migPlan?.status?.destStorageClasses || [];
   pvStorageClassAssignment = migPlanPvs.reduce((assignedScs, pv) => {
     const suggestedStorageClass = storageClasses.find(
-      (sc) => (sc !== '' && sc.name) === pv.selection.storageClass
+      (sc) => sc.name === pv.selection.storageClass
     );
+    const copy = JSON.parse(JSON.stringify(suggestedStorageClass));
+    copy.volumeMode = pv.pvc.volumeMode;
+    copy.accessMode = pv.pvc.accessModes[0] || 'ReadWriteOnce';
     return {
       ...assignedScs,
-      [pv.name]: suggestedStorageClass ? suggestedStorageClass : '',
+      [pv.name]: copy || '',
     };
   }, {});
   return pvStorageClassAssignment;

--- a/src/app/plan/duck/types.ts
+++ b/src/app/plan/duck/types.ts
@@ -12,6 +12,8 @@ export interface IPlanPersistentVolume {
   pvc: {
     namespace: string;
     name: string;
+    volumeMode: string;
+    accessModes: string[];
   };
   storageClass?: string;
   capacity: string;
@@ -27,10 +29,17 @@ export interface IPlanPersistentVolume {
   };
 }
 
-export type IMigPlanStorageClass = IMigPlanStorageClassPopulated | '';
-type IMigPlanStorageClassPopulated = {
+export type IVolumeAccessModes = {
+  volumeMode: string;
+  accessModes: string[];
+};
+
+export type IMigPlanStorageClass = {
   name: string;
   provisioner: string;
+  volumeMode: string;
+  volumeAccessModes: IVolumeAccessModes[];
+  accessMode: string;
 };
 
 export interface IPlanSpecHook {

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -465,9 +465,10 @@ export function updateMigPlanFromValues(
         planValues.pvVerifyFlagAssignment[updatedPV.name];
 
       const selectedStorageClassObj = planValues.pvStorageClassAssignment[updatedPV.name];
-      if (selectedStorageClassObj || selectedStorageClassObj === '') {
-        updatedPV.selection.storageClass =
-          selectedStorageClassObj !== '' ? selectedStorageClassObj.name : '';
+      if (selectedStorageClassObj !== undefined) {
+        updatedPV.selection.storageClass = selectedStorageClassObj.name;
+        updatedPV.pvc.volumeMode = selectedStorageClassObj.volumeMode;
+        updatedPV.pvc.accessModes = [selectedStorageClassObj.accessMode];
       }
       const isPVSelected = planValues.selectedPVs.includes(pvItem.name);
       if (!isPVSelected) updatedPV.selection.action = 'skip';


### PR DESCRIPTION
This allows the user to change the volume mode and access mode for volumes that are part of a VM. Defaults to 'auto' which means that the created volumes will allow the datavolume to pick the optimal values.

Removed the 'none' option from the TargetStorageClass dropdown. Not sure what the purpose was, maybe use the 'default' storage class. But there is no guarantee there is a default storage class set.