### PR TITLE
If a migration ends in errors, then disable the

### DIFF
--- a/src/app/home/pages/PlansPage/helpers.ts
+++ b/src/app/home/pages/PlansPage/helpers.ts
@@ -480,6 +480,8 @@ export const migSpecToAction = (
     if (spec.stage) return 'stage';
     else return 'cutover';
   }
+  // If the migration has errors, return undefined so rollback is disabled.
+  if (migration.status?.errors) return undefined;
   return MIGRATION_ACTIONS.find((action) => {
     const possibleSpec = migSpecByAction[type][action];
     const fieldsToCompare =


### PR DESCRIPTION
rollback option in the plan table page.

An error happens in a check before the migration
actually starts, so a rollback is not possible.