### PR TITLE
Fixed namespace selection dropdown

### DIFF
--- a/src/app/common/duck/hooks.ts
+++ b/src/app/common/duck/hooks.ts
@@ -12,7 +12,10 @@ export const useFilterState = (items: any[], filterCategories: FilterCategory[])
       const values = filterValues[categoryKey];
       if (!values || values.length === 0) return true;
       const filterCategory = filterCategories.find((category) => category.key === categoryKey);
-      let itemValue = item['pvc'][categoryKey];
+      let itemValue = item[categoryKey];
+      if (item['pvc']) {
+        itemValue = item['pvc'][categoryKey];
+      }
       if (filterCategory.getItemValue) {
         itemValue = filterCategory.getItemValue(item);
       }


### PR DESCRIPTION
Same filter logic was used for all dropdowns and not all filter items have 'pvc' in them. This ensures that only if 'pvc' exists will we attempt to use it to filter.