### PR TITLE
Don't spin forever on no persistent volumes

### DIFF
--- a/src/app/home/pages/PlansPage/components/Wizard/VolumesForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/VolumesForm.tsx
@@ -106,10 +106,7 @@ const VolumesForm: React.FunctionComponent<IOtherProps> = (props) => {
       </Grid>
     );
   }
-  if (
-    !planState.currentPlan?.spec.persistentVolumes ||
-    planState.currentPlan.spec.persistentVolumes?.length == 0
-  ) {
+  if (!planState.currentPlan?.status) {
     return (
       <Bullseye>
         <EmptyState variant="large">


### PR DESCRIPTION
If you selected a namespace without persistent volumes The spinner would never disappear since the spec
in the MigPlan would never container persistentVolumes

Instead spin as long as the status is not there this causes the spinner to disappear even if there are no persistent volumes.